### PR TITLE
Podman compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A streamable HTTP MCP server will now be available at: http://localhost:8080/
 DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector
 ```
 
-1. Open http://127.0.0.1:6274/?transport=streamable-http&serverUrl=http://localhost:8080#resources
+1. Open http://localhost:6274/?transport=streamable-http&serverUrl=http://localhost:8080#resources
 2. Click **Connect**
 3. Click **List Tools**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command: ["envoy", "-c", "/etc/envoy/envoy.yaml", "--log-level", "info"]
     depends_on:
       - mcp_helper
-
+    tty: true
   mcp_helper:
     container_name: mcp_helper
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,13 +23,19 @@ services:
     depends_on:
       - server1
       - server2
+    ports:
+      - "50051:50051"  # Direct connection (for debugging only)
 
   server1:
     container_name: server1
     build: ./server1
     image: quay.io/dmartin/mcp-helper-server1
+    ports:
+      - "8081:8081"  # Direct connection (for debugging only)
 
   server2:
     container_name: server2
     build: ./server2
-    image: quay.io/dmartin/mcp-helper-server2 
+    image: quay.io/dmartin/mcp-helper-server2
+    ports:
+      - "8082:8082"  # Direct connection (for debugging only)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 // getEnv gets an environment variable or returns a default value
@@ -127,6 +128,9 @@ func main() {
 
 	s := grpc.NewServer()
 	extProcPb.RegisterExternalProcessorServer(s, extProc.NewServer(false, helper))
+
+	// Register reflection service on gRPC server (for debugging only)
+	reflection.Register(s)
 
 	log.Println("Starting ext-proc gRPC server on :50051")
 


### PR DESCRIPTION
This PR includes support for Podman as a back end with Docker as CLI.

This PR exposes the internal ports for testing.
This PR adds gRPC reflection for testing with grpcurl.  For example, with this test you can do `grpcurl --plaintext localhost:50051 list `